### PR TITLE
Fix Dependencies, info via Dries007

### DIFF
--- a/resources/mcmod.info
+++ b/resources/mcmod.info
@@ -11,6 +11,8 @@
   "credits": "",
   "logoFile": "",
   "screenshots": [],
-  "dependencies": []
+  "requiredMods": [ "terrafirmacraft"],
+  "dependencies": ["terrafirmacraft"],
+  "dependants": []
 }
 ]

--- a/src/com/aleksey/decorations/DecorationsMod.java
+++ b/src/com/aleksey/decorations/DecorationsMod.java
@@ -23,7 +23,7 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.registry.ExistingSubstitutionException;
 
-@Mod(modid="DecorationsTFC", name="Decorations", version="1.0.19", dependencies="required-after:terrafirmacraft")
+@Mod(modid="DecorationsTFC", name="Decorations", version="1.0.19")
 public class DecorationsMod
 {
     @Instance("DecorationsTFC")


### PR DESCRIPTION
This PR should solve the crash:
`java.lang.NullPointerException: 

```
at com.bioxx.tfc.Core.TFC_Core.getSuperSeed(TFC_Core.java:1421)
at com.bioxx.tfc.api.Crafting.AnvilRecipe.<init>(AnvilRecipe.java:30)
at com.aleksey.merchants.Core.Recipes.registerAnvilRecipes(Recipes.java:73)
at com.aleksey.merchants.Handlers.ChunkEventHandler.onLoadWorld(ChunkEventHandler.java:16)
at cpw.mods.fml.common.eventhandler.ASMEventHandler_0_ChunkEventHandler_onLoadWorld_Load.invoke(.dynamic:-1)
at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:138)
at net.minecraft.server.integrated.IntegratedServer.func_71247_a(IntegratedServer.java:73)
at net.minecraft.server.integrated.IntegratedServer.func_71197_b(IntegratedServer.java:92)
at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:387)
at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)`
```

This was caused by Merchants occasional loading before TFC. More common with Decorations.

info from Dries007
You either have to specify @Mod.useMetadata = false and use @Mod.dependencies = ...
OR
Specify all dependencies in the mcmod.info file.
